### PR TITLE
Switch ads visibility from quicktags to post meta (metabox)

### DIFF
--- a/includes/quicktags.php
+++ b/includes/quicktags.php
@@ -20,11 +20,11 @@ add_filter( 'content_save_pre', 'quads_strip_quicktags_from_content' );
  * @return string Filtered content
  */
 function quads_strip_quicktags_from_content ( $content ) {
-	$ads_visibility_config = get_post_meta( get_the_ID(), '_quads_config_visibility', true );
+	$config_exists = false !== get_post_meta( get_the_ID(), '_quads_config_visibility', true );
 
 	// if config exists, quicktags are handled via metabox
 	// so we don't need them anymore in the content
-	if ( $ads_visibility_config ) {
+	if ( $config_exists ) {
 		$content = quads_strip_quicktags( $content );
 	}
 

--- a/includes/quicktags.php
+++ b/includes/quicktags.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Quicktags functions
+ *
+ * @package     QUADS
+ * @subpackage  Functions/Quicktags
+ * @copyright   Copyright (c) 2015, René Hermenau
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       0.9.4
+ */
+
+add_filter( 'content_edit_pre', 'quads_strip_quicktags_from_content' );
+add_filter( 'content_save_pre', 'quads_strip_quicktags_from_content' );
+
+/**
+ * Removes all quicktags from content, but only if their config is already stored in post meta
+ *
+ * @param string $content
+ * @return string Filtered content
+ */
+function quads_strip_quicktags_from_content ( $content ) {
+	$ads_visibility_config = get_post_meta( get_the_ID(), '_quads_config_visibility', true );
+
+	// if config exists, quicktags are handled via metabox
+	// so we don't need them anymore in the content
+	if ( $ads_visibility_config ) {
+		$content = quads_strip_quicktags( $content );
+	}
+
+	return $content;
+}
+
+/**
+ * Returns an array of all quicktags found in content
+ *
+ * @param string $content
+ * @return array List of quicktags
+ */
+function quads_get_quicktags_from_content ( $content ) {
+	$found = array();
+	$quicktags = quads_quicktag_list();
+
+	// we can use preg_match instead of multiple calls of strpos(),
+	// but strpos is much faster and for such a small array should still be faster than preg_match()
+	foreach ( $quicktags as $id => $label ) {
+		if ( false !== strpos( $content, '<!--' . $id . '-->' ) ) {
+			$found[ $id ] = 1;
+		}
+	}
+
+	return $found;
+}
+
+/**
+ * Removes all quicktags from content
+ *
+ * @param string $content
+ * @return string Filtered content
+ */
+function quads_strip_quicktags ( $content ) {
+	$quicktags = quads_quicktag_list();
+
+	foreach ( $quicktags as $id => $label ) {
+		$content = str_replace( '<!--'. $id .'-->', '', $content );
+	}
+
+	return $content;
+}
+
+/**
+ * Returns list of all allowed quicktags
+ *
+ * @return array List of quicktags
+ */
+function quads_quicktag_list () {
+	return apply_filters( 'quads_quicktag_list', array(
+		'NoAds' 		=> __( '<!--NoAds-->', 'quick-adsense-reloaded' ),
+		'OffDef'		=> __( '<!--OffDef-->', 'quick-adsense-reloaded' ),
+		'OffWidget'		=> __( '<!--OffWidget-->', 'quick-adsense-reloaded' ),
+		'OffBegin'		=> __( '<!--OffBegin-->', 'quick-adsense-reloaded' ),
+		'OffMiddle'		=> __( '<!--OffMiddle-->', 'quick-adsense-reloaded' ),
+		'OffEnd'		=> __( '<!--OffEnd-->', 'quick-adsense-reloaded' ),
+		'OffAfMore'		=> __( '<!--OffAfMore-->', 'quick-adsense-reloaded' ),
+		'OffBfLastPara'	=> __( '<!--OffBfLastPara-->', 'quick-adsense-reloaded' ),
+	) );
+}

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -42,11 +42,13 @@ function quads_get_visibility_quicktags_str ( $post_id = null ) {
 		$post_id = get_the_ID();
 	}
 
-	$config = get_post_meta( $post_id, '_quads_config_visibility', true );
 	$str = '';
+	$config = get_post_meta( $post_id, '_quads_config_visibility', true );
 
-	foreach ( $config as $qtag_id => $qtag_label ) {
-		$str .= '<!--' . $qtag_id . '-->';
+	if ( $config ) {
+		foreach ( $config as $qtag_id => $qtag_label ) {
+			$str .= '<!--' . $qtag_id . '-->';
+		}
 	}
 
 	return $str;

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -12,8 +12,45 @@
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+// we need to hook into the_content on lower than default priority (that's why we use separate hook)
+add_filter('the_content', 'quads_post_settings_to_quicktags', 5);
 add_filter('the_content', 'quads_process_content', 20);
 
+/**
+ * Adds quicktags, defined via post meta options, to content.
+ *
+ * @param $content 		Post content
+ *
+ * @return string
+ */
+function quads_post_settings_to_quicktags ( $content ) {
+	$quicktags_str = quads_get_visibility_quicktags_str();
+
+	return $content . $quicktags_str;
+}
+
+/**
+ * Returns quicktags based on post meta options.
+ * These quicktags define which ads should be hidden on current page.
+ *
+ * @param null $post_id 	Post id
+ *
+ * @return string
+ */
+function quads_get_visibility_quicktags_str ( $post_id = null ) {
+	if ( ! $post_id ) {
+		$post_id = get_the_ID();
+	}
+
+	$config = get_post_meta( $post_id, '_quads_config_visibility', true );
+	$str = '';
+
+	foreach ( $config as $qtag_id => $qtag_label ) {
+		$str .= '<!--' . $qtag_id . '-->';
+	}
+
+	return $str;
+}
 /**
  * Main processing for the_content filter
  * 
@@ -36,33 +73,33 @@ function quads_process_content($content)
 {
 	global $quads_options, $ShownAds, $AdsId, $numberWidgets, $numberAds, $AdsWidName, $ad_count_content, $ad_count_shortcode;
 
-        if ( !quads_ad_is_allowed($content) ) {
-            $content = quads_clean_tags($content); 
-            return $content;
-        }
+	if ( !quads_ad_is_allowed($content) ) {
+		$content = quads_clean_tags($content);
+		return $content;
+	}
          
-        $AdsToShow = $quads_options['maxads'];
-        //$showall = isset($quads_options['visibility']['AppMaxA']) ? $quads_options['visibility']['AppMaxA'] : 0;
-        // @deprecated since 0.9.4
+	$AdsToShow = $quads_options['maxads'];
+	//$showall = isset($quads_options['visibility']['AppMaxA']) ? $quads_options['visibility']['AppMaxA'] : 0;
+	// @deprecated since 0.9.4
 	/* verifying */ 
 	/*if(	(is_feed()) ||
-                (strpos($content,'<!--NoAds-->')!==false) ||
-                (strpos($content,'<!--OffAds-->')!==false) ||
-                (is_single() && !( isset( $quads_options['visibility']['AppPost'] ) ) ) ||
-                (is_page() && !( isset($quads_options['visibility']['AppPage'] ) ) ) ||
-                (is_home() && !( isset( $quads_options['visibility']['AppHome'] ) ) ) ||			
-                (is_category() && !(isset( $quads_options['visibility']['AppCate'] ) ) ) ||
-                (is_archive() && !( isset($quads_options['visibility']['AppArch'] ) ) ) ||
-                (is_tag() && !( isset($quads_options['visibility']['AppTags'] ) ) ) ||
-                (is_user_logged_in() && ( isset($quads_options['visibility']['AppLogg'] ) ) ) ) 
+		(strpos($content,'<!--NoAds-->')!==false) ||
+		(strpos($content,'<!--OffAds-->')!==false) ||
+		(is_single() && !( isset( $quads_options['visibility']['AppPost'] ) ) ) ||
+		(is_page() && !( isset($quads_options['visibility']['AppPage'] ) ) ) ||
+		(is_home() && !( isset( $quads_options['visibility']['AppHome'] ) ) ) ||
+		(is_category() && !(isset( $quads_options['visibility']['AppCate'] ) ) ) ||
+		(is_archive() && !( isset($quads_options['visibility']['AppArch'] ) ) ) ||
+		(is_tag() && !( isset($quads_options['visibility']['AppTags'] ) ) ) ||
+		(is_user_logged_in() && ( isset($quads_options['visibility']['AppLogg'] ) ) ) )
         {
-                    $content = quads_clean_tags($content); 
-                    return $content; 
-	}
+			$content = quads_clean_tags($content);
+			return $content;
+		}
         
-        if (!is_main_query())
-            return $content;
-         */
+	if (!is_main_query())
+		return $content;
+	 */
 
 	if (strpos($content,'<!--OffWidget-->')===false) {
 		for($i=1;$i<=$numberWidgets;$i++) {

--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -57,7 +57,7 @@ class quads_widgets_1 extends WP_Widget {
         global $quads_options;
         extract($args);
             
-        $cont = get_the_content();
+        $cont = quads_post_settings_to_quicktags( get_the_content() );
         if (strpos($cont, "<!--OffAds-->") === false && strpos($cont, "<!--OffWidget-->") === false && !(is_home() && $quads_options["visibility"]["AppSide"])) {
 
             $codetxt = $quads_options['ad' . $this->adsID . '_widget'];
@@ -95,7 +95,7 @@ class quads_widgets_2 extends WP_Widget {
         global $quads_options;
         extract($args);
         
-        $cont = get_the_content();
+        $cont = quads_post_settings_to_quicktags( get_the_content() );
         if (strpos($cont, "<!--OffAds-->") === false && strpos($cont, "<!--OffWidget-->") === false && !(is_home() && $quads_options["visibility"]["AppSide"])) {
 
 
@@ -135,7 +135,7 @@ class quads_widgets_3 extends WP_Widget {
         global $quads_options;
         extract($args);
 
-        $cont = get_the_content();
+        $cont = quads_post_settings_to_quicktags( get_the_content() );
         if (strpos($cont, "<!--OffAds-->") === false && strpos($cont, "<!--OffWidget-->") === false && !(is_home() && $quads_options["visibility"]["AppSide"])) {
 
             $codetxt = $quads_options['ad' . $this->adsID . '_widget'];
@@ -174,7 +174,7 @@ class quads_widgets_4 extends WP_Widget {
         
         extract($args);
 
-        $cont = get_the_content();
+        $cont = quads_post_settings_to_quicktags( get_the_content() );
         if (strpos($cont, "<!--OffAds-->") === false && strpos($cont, "<!--OffWidget-->") === false && !(is_home() && $quads_options["visibility"]["AppSide"])) {
             
              
@@ -216,7 +216,7 @@ class quads_widgets_5 extends WP_Widget {
         
         extract($args);
 
-        $cont = get_the_content();
+        $cont = quads_post_settings_to_quicktags( get_the_content() );
         if (strpos($cont, "<!--OffAds-->") === false && strpos($cont, "<!--OffWidget-->") === false && !(is_home() && $quads_options["visibility"]["AppSide"])) {
 
              
@@ -257,7 +257,7 @@ class quads_widgets_6 extends WP_Widget {
         
         extract($args);
 
-        $cont = get_the_content();
+        $cont = quads_post_settings_to_quicktags( get_the_content() );
         if (strpos($cont, "<!--OffAds-->") === false && strpos($cont, "<!--OffWidget-->") === false && !(is_home() && $quads_options["visibility"]["AppSide"])) {
             
              
@@ -298,7 +298,7 @@ class quads_widgets_7 extends WP_Widget {
         
         extract($args);
 
-        $cont = get_the_content();
+        $cont = quads_post_settings_to_quicktags( get_the_content() );
         if (strpos($cont, "<!--OffAds-->") === false && strpos($cont, "<!--OffWidget-->") === false && !(is_home() && $quads_options["visibility"]["AppSide"])) {
             
              
@@ -339,7 +339,7 @@ class quads_widgets_8 extends WP_Widget {
         
         extract($args);
 
-        $cont = get_the_content();
+        $cont = quads_post_settings_to_quicktags( get_the_content() );
         if (strpos($cont, "<!--OffAds-->") === false && strpos($cont, "<!--OffWidget-->") === false && !(is_home() && $quads_options["visibility"]["AppSide"])) {
             
             $codetxt = $quads_options['ad' . $this->adsID . '_widget'];
@@ -378,7 +378,7 @@ class quads_widgets_9 extends WP_Widget {
         
         extract($args);
 
-        $cont = get_the_content();
+        $cont = quads_post_settings_to_quicktags( get_the_content() );
         if (strpos($cont, "<!--OffAds-->") === false && strpos($cont, "<!--OffWidget-->") === false && !(is_home() && $quads_options["visibility"]["AppSide"])) {
             
              
@@ -419,7 +419,8 @@ class quads_widgets_10 extends WP_Widget {
         
         extract($args);
 
-        $cont = get_the_content();
+        $cont = quads_post_settings_to_quicktags( get_the_content() );
+
         if (strpos($cont, "<!--OffAds-->") === false && strpos($cont, "<!--OffWidget-->") === false && !(is_home() && $quads_options["visibility"]["AppSide"])) {
             
              

--- a/quick-adsense-reloaded.php
+++ b/quick-adsense-reloaded.php
@@ -190,6 +190,7 @@ if (!class_exists('QuickAdsenseReloaded')) :
                 require_once QUADS_PLUGIN_DIR . 'includes/admin/settings/contextual-help.php';
                 require_once QUADS_PLUGIN_DIR . 'includes/install.php';
                 require_once QUADS_PLUGIN_DIR . 'includes/admin/tools.php';
+                require_once QUADS_PLUGIN_DIR . 'includes/quicktags.php';
                 require_once QUADS_PLUGIN_DIR . 'includes/meta-boxes.php';
             }
         }

--- a/quick-adsense-reloaded.php
+++ b/quick-adsense-reloaded.php
@@ -190,7 +190,7 @@ if (!class_exists('QuickAdsenseReloaded')) :
                 require_once QUADS_PLUGIN_DIR . 'includes/admin/settings/contextual-help.php';
                 require_once QUADS_PLUGIN_DIR . 'includes/install.php';
                 require_once QUADS_PLUGIN_DIR . 'includes/admin/tools.php';
-                //require_once QUADS_PLUGIN_DIR . 'includes/meta-boxes.php';
+                require_once QUADS_PLUGIN_DIR . 'includes/meta-boxes.php';
             }
         }
 


### PR DESCRIPTION
How it works?
1. on a single post the "Hide ads" meta box was introduced. By default, the meta box is supported only via post and page post type but of course is a hook to override that.
2. when first loaded, the meta box will be set up based on current quicktags (from content).
3. content quicktags will be stripped after first save.
4. from this point, quicktags will be handled only via meta box.
5. if someone add a quicktag to content (manually or via some legacy code), it'll be stripped to notify a user that this form of setup is no longer available.
6. to keep backward compatibility post meta config is translated to quicktags string that is added at the end of the content, on front end (via "the_content" hook, with low priority).
All depended plugin code (that relies on quicktags string presence in the content string) will still work and there's no need to rewrite anything (for now, this is a future task).

What should be done now?
1. Remove quicktag buttons (only these responsible for hiding ads) from WP editor toolbar.
2. Remove all related configs for these quicktags, from plugin settings page.
3. Tests. To make sure that I didn't miss anything (for current and future users) this change should be heavy tested.